### PR TITLE
querry error jUnit test

### DIFF
--- a/src/test/java/org/activiti/MyUnitTest.java
+++ b/src/test/java/org/activiti/MyUnitTest.java
@@ -1,26 +1,37 @@
 package org.activiti;
+
+import org.activiti.engine.TaskService;
 import org.activiti.engine.runtime.ProcessInstance;
 import org.activiti.engine.task.Task;
 import org.activiti.engine.test.ActivitiRule;
-import org.activiti.engine.test.Deployment;
 import org.junit.Rule;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class MyUnitTest {
-	
+
 	@Rule
 	public ActivitiRule activitiRule = new ActivitiRule();
-	
+
 	@Test
-	@Deployment(resources = {"org/activiti/test/my-process.bpmn20.xml"})
 	public void test() {
 		ProcessInstance processInstance = activitiRule.getRuntimeService().startProcessInstanceByKey("my-process");
 		assertNotNull(processInstance);
-		
+
 		Task task = activitiRule.getTaskService().createTaskQuery().singleResult();
 		assertEquals("Activiti is awesome!", task.getName());
 	}
 
+	@Test
+	public void queryTest() {
+		TaskService taskService = this.activitiRule.getTaskService();
+
+		assertEquals(
+				taskService.createTaskQuery().includeProcessVariables().active().list().size()
+				,
+				taskService.createTaskQuery().active().list().size());
+
+	}
 }


### PR DESCRIPTION
This unit test fails with Activiti 5.17 : i get different results when ProcessVariables are included in the query.
